### PR TITLE
Fix health reports blinking by optimizing state calculations

### DIFF
--- a/src/components/HealthReportsScreen.tsx
+++ b/src/components/HealthReportsScreen.tsx
@@ -84,10 +84,6 @@ const HealthReportsScreen: React.FC = () => {
     };
   }, [sortedCycles]);
 
-  useEffect(() => {
-    setTrendData(calculatedTrends);
-    setAverageStats(calculatedStats);
-  }, [calculatedTrends, calculatedStats]);
 
   // SEO: title and meta description
   useEffect(() => {


### PR DESCRIPTION
## Purpose
Fix the blinking issue in health reports where cycle length trends and period comparison data were constantly recalculating and causing visual flickering. The user reported that these sections were unstable and distracting during use.

## Code changes
- **Replaced useState with useMemo**: Converted `trendData` and `averageStats` from state variables to memoized calculations (`calculatedTrends` and `calculatedStats`)
- **Removed useEffect dependencies**: Eliminated the problematic useEffect that was triggering frequent recalculations
- **Optimized calculations**: Made trend and statistics calculations only run when underlying data actually changes
- **Added useMemo for sortedCycles**: Memoized the filtered and sorted cycles array to prevent unnecessary recomputation
- **Updated all references**: Changed all component references to use the new memoized values instead of state

The changes ensure that calculations only happen when the underlying cycle data changes, eliminating the constant re-renders that caused the blinking behavior.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a866d86c548043c68bd4fe3d02168132/flare-hub)

👀 [Preview Link](https://a866d86c548043c68bd4fe3d02168132-flare-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a866d86c548043c68bd4fe3d02168132</projectId>-->
<!--<branchName>flare-hub</branchName>-->